### PR TITLE
Remove Duplicate Menu Items in menu.php

### DIFF
--- a/menu.php
+++ b/menu.php
@@ -515,22 +515,6 @@ session_start();
     </div>
 </div>
 
-<!-- Item A4 -->
-<div class="col-md-4">
-    <div class="menu-card" data-id="24" data-name="Stuffed Mushrooms" data-price="149"
-         data-img="https://images.unsplash.com/photo-1603048335149-4fc0f8a2e74e">
-        <img src="https://images.unsplash.com/photo-1603048335149-4fc0f8a2e74e" class="menu-img" alt="Stuffed Mushrooms">
-        <div class="menu-body">
-            <h3 class="menu-title"><i class="fas fa-leaf veg-icon"></i> Stuffed Mushrooms <span class="menu-rating">★ 4.6</span></h3>
-            <p class="menu-description">Mushrooms stuffed with cheese and herbs.</p>
-            <div class="d-flex justify-content-between align-items-center">
-                <span class="menu-price">₹149</span>
-                <button class="add-to-cart btn btn-danger">Add to Cart</button>
-            </div>
-        </div>
-    </div>
-</div>
-
 <!-- Item A6 -->
 <div class="col-md-4">
     <div class="menu-card" data-id="26" data-name="Onion Rings" data-price="149"


### PR DESCRIPTION
## **Description:**
This PR resolves the issue #2  of duplicate menu entries found in menu.php, ensuring consistency and accuracy in the displayed menu data.

## **🔧 Changes Made:**

1. Removed duplicate items (e.g., “Stuffed Mushrooms” appearing twice).
2. Standardized menu data to ensure each dish appears only once with the correct price.
3. Verified all menu entries for correctness and uniqueness.

## **Testing:**

Checked that no duplicate items appear on the menu page.
Ensured data loads correctly and prices display as expected.

## **🏷️ Type of Change:**

 Bug Fix #2 
